### PR TITLE
Remove deprecated MUI Grid

### DIFF
--- a/src/Components/Molecule/DistanceTool/DistanceTool.tsx
+++ b/src/Components/Molecule/DistanceTool/DistanceTool.tsx
@@ -1,6 +1,7 @@
 import { Typography } from "@mui/material";
 import Button from "@mui/material/Button";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 
 interface DistanceToolProps {
   pinOneActive: boolean;
@@ -22,34 +23,34 @@ export default function DistanceTool({
   distance,
 }: DistanceToolProps) {
   return (
-    <Grid container direction="row">
-      <Grid container item direction="row" xs={6}>
-        <Grid item>
+    <Stack direction="row">
+      <Stack direction="row" sx={{ width: "50%" }}>
+        <Box>
           <Button
             disabled={pinOneActive}
             onClick={() => handlePinOneActive(true)}
           >
             Start
           </Button>
-        </Grid>
-        <Grid item>
+        </Box>
+        <Box>
           <Button
             disabled={!pinOneActive}
             onClick={() => handlePinOneActive(false)}
           >
             Destination
           </Button>
-        </Grid>
-      </Grid>
+        </Box>
+      </Stack>
       {isPinOneVisable && isPinTwoVisable ? (
-        <Grid item xs={6} alignSelf="center">
+        <Box sx={{ width: "50%", alignSelf: "center" }}>
           <Typography textAlign="end" variant="body1">
             {`Distance: `}
             {((distance || 0) * detail).toFixed(1)}
             {unitOfDistance}
           </Typography>
-        </Grid>
+        </Box>
       ) : null}
-    </Grid>
+    </Stack>
   );
 }

--- a/src/Components/Molecule/MissionDetails/MissionDetails.tsx
+++ b/src/Components/Molecule/MissionDetails/MissionDetails.tsx
@@ -1,5 +1,6 @@
 import Button from "@mui/material/Button";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { setActiveMission } from "../../../Store/slices/activeMission";
 import { MissionLocation } from "../../../Types/Interfaces/missions.interface";
@@ -42,52 +43,52 @@ export default function MissionDetails({
   };
   return (
     <>
-      <Grid item flexDirection="row" marginBottom={4}>
+      <Box mb={4}>
         <Typography variant="h3" textAlign="center">
           {missionName}
         </Typography>
-      </Grid>
-      <Grid container item flexDirection="row">
-        <Grid item xs={5}>
+      </Box>
+      <Stack direction="row">
+        <Box sx={{ width: "50%" }}>
           <Typography variant="h4">Location:</Typography>
-        </Grid>
-        <Grid item xs={5}>
+        </Box>
+        <Box sx={{ width: "50%" }}>
           <Typography variant="h5">{location}</Typography>
-        </Grid>
-      </Grid>
-      <Grid container item flexDirection="row">
-        <Grid item xs={5}>
+        </Box>
+      </Stack>
+      <Stack direction="row">
+        <Box sx={{ width: "50%" }}>
           <Typography variant="h4">Who:</Typography>
-        </Grid>
-        <Grid item xs={5}>
+        </Box>
+        <Box sx={{ width: "50%" }}>
           <Typography variant="h5">{setter}</Typography>
-        </Grid>
-      </Grid>
-      <Grid container item flexDirection="row">
-        <Grid item xs={5}>
+        </Box>
+      </Stack>
+      <Stack direction="row">
+        <Box sx={{ width: "50%" }}>
           <Typography variant="h4">Reward:</Typography>
-        </Grid>
-        <Grid item xs={5}>
+        </Box>
+        <Box sx={{ width: "50%" }}>
           <Typography variant="h5">{reward}</Typography>
-        </Grid>
-      </Grid>
-      <Grid container item flexDirection="column">
-        <Grid item>
+        </Box>
+      </Stack>
+      <Stack direction="column">
+        <Box>
           <Typography variant="h4">Description:</Typography>
-        </Grid>
-        <Grid item>
+        </Box>
+        <Box>
           <Typography variant="h6">{description}</Typography>
-        </Grid>
-      </Grid>
+        </Box>
+      </Stack>
       {missionLocation?.name ? (
-        <Grid container item flexDirection="row">
-          <Grid item>
+        <Stack direction="row">
+          <Box>
             <Typography variant="h4">View on Map: </Typography>
-          </Grid>
-          <Grid item>
+          </Box>
+          <Box>
             <Button onClick={handleMissionSelect}>Map</Button>
-          </Grid>
-        </Grid>
+          </Box>
+        </Stack>
       ) : null}
     </>
   );

--- a/src/Components/Molecule/Navbar/Navbar.tsx
+++ b/src/Components/Molecule/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
@@ -41,15 +41,15 @@ export default function Navbar({ onMenuButtonClick }: INavbarProps) {
           "linear-gradient(90deg, #ff9003 0%, rgba(0,212,255,1) 100%)",
       }}
     >
-      <Grid container direction="row">
-        <Grid item xs={3} textAlign="center">
+      <Stack direction="row">
+        <Box sx={{ width: "25%", textAlign: "center" }}>
           {location.pathname !== "/" ? (
             <Button onClick={() => navigate(-1)}>
               <ArrowBackIosIcon color="secondary" />
             </Button>
           ) : null}
-        </Grid>
-        <Grid item xs={6}>
+        </Box>
+        <Box sx={{ width: "50%" }}>
           <Link
             style={{
               textDecoration: "none",
@@ -61,8 +61,8 @@ export default function Navbar({ onMenuButtonClick }: INavbarProps) {
               Teratin
             </Typography>
           </Link>
-        </Grid>
-        <Grid item xs={3} textAlign="center">
+        </Box>
+        <Box sx={{ width: "25%", textAlign: "center" }}>
           <Button
             data-testid="menu__button"
             variant="contained"
@@ -71,8 +71,8 @@ export default function Navbar({ onMenuButtonClick }: INavbarProps) {
           >
             <Typography sx={{ color: "#ffff" }}>Menu</Typography>
           </Button>
-        </Grid>
-      </Grid>
+        </Box>
+      </Stack>
     </Box>
   );
 }

--- a/src/Components/Molecule/Section/Section.tsx
+++ b/src/Components/Molecule/Section/Section.tsx
@@ -1,6 +1,7 @@
 import { ISection } from "../../../Types/Interfaces/content.interface";
 import Typography from "@mui/material/Typography";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 
 export interface ISectionProps extends ISection {}
 
@@ -10,36 +11,32 @@ export default function Section({
   swapSections,
 }: ISectionProps) {
   return (
-    <Grid item container direction="row">
+    <Stack direction="row">
       {swapSections ? (
-        <>
-          <Grid item>
-            <Typography data-testid="section_element" textAlign="justify">
-              {textBlock.displayText}
-            </Typography>
-            <img
-              style={{ width: "50vw" }}
-              data-testid="section_element"
-              alt={image.altText}
-              src={image.imageSrc}
-            />
-          </Grid>
-        </>
+        <Box>
+          <Typography data-testid="section_element" textAlign="justify">
+            {textBlock.displayText}
+          </Typography>
+          <img
+            style={{ width: "50vw" }}
+            data-testid="section_element"
+            alt={image.altText}
+            src={image.imageSrc}
+          />
+        </Box>
       ) : (
-        <>
-          <Grid item>
-            <img
-              data-testid="section_element"
-              style={{ width: "40vw", float: "left", marginRight: "5px" }}
-              alt={image.altText}
-              src={image.imageSrc}
-            />
-            <Typography data-testid="section_element" textAlign="justify">
-              {textBlock.displayText}
-            </Typography>
-          </Grid>
-        </>
+        <Box>
+          <img
+            data-testid="section_element"
+            style={{ width: "40vw", float: "left", marginRight: "5px" }}
+            alt={image.altText}
+            src={image.imageSrc}
+          />
+          <Typography data-testid="section_element" textAlign="justify">
+            {textBlock.displayText}
+          </Typography>
+        </Box>
       )}
-    </Grid>
+    </Stack>
   );
 }

--- a/src/Components/Organism/TimelineItem/TimelineItem.tsx
+++ b/src/Components/Organism/TimelineItem/TimelineItem.tsx
@@ -8,7 +8,8 @@ import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import Typography from "@mui/material/Typography";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 
 interface TimelineItemProps {
   title: string;
@@ -32,22 +33,18 @@ export default function TimelineItem({
       <TimelineContent>
         <Accordion>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Grid
-              container
-              justifyContent="space-between"
-              flexDirection={order}
-            >
-              <Grid item>
+            <Stack justifyContent="space-between" direction={order}>
+              <Box>
                 <Typography fontSize={20} variant="h3">
                   {year}
                 </Typography>
-              </Grid>
-              <Grid item>
+              </Box>
+              <Box>
                 <Typography fontSize={30} variant="h3">
                   {title}
                 </Typography>
-              </Grid>
-            </Grid>
+              </Box>
+            </Stack>
           </AccordionSummary>
           <AccordionDetails>
             <Typography textAlign="justify">{summary}</Typography>

--- a/src/Pages/Content/Content.tsx
+++ b/src/Pages/Content/Content.tsx
@@ -1,4 +1,4 @@
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
 import { useNavigate, useParams } from "react-router-dom";
 import { useGetContentPageQuery } from "../../Store/slices/backend";
 import Skeleton from "@mui/material/Skeleton";
@@ -17,7 +17,7 @@ export default function Content() {
   }, [error, data, navigate, isLoading]);
 
   return (
-    <Grid container item direction="column" maxWidth="100vw">
+    <Stack direction="column" maxWidth="100vw">
       {data && !isLoading ? (
         <>
           <StyledTypography variant="h3" textAlign="center">
@@ -30,6 +30,6 @@ export default function Content() {
       ) : (
         <Skeleton variant="text" />
       )}
-    </Grid>
+    </Stack>
   );
 }

--- a/src/Pages/Documents/Documents.tsx
+++ b/src/Pages/Documents/Documents.tsx
@@ -1,7 +1,8 @@
 import Typography from "@mui/material/Typography";
 import MuiList from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 import { useGetDocumentPageQuery } from "../../Store/slices/backend";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
@@ -21,16 +22,16 @@ export default function Documents() {
   }, [error, data, isLoading, navigate]);
 
   const body = isSuccess ? (
-    <Grid container direction="column">
-      <Grid item>
+    <Stack direction="column">
+      <Box>
         <Typography variant="h3">{data.pageTitle}</Typography>
-      </Grid>
-      <Grid item>
+      </Box>
+      <Box>
         <Typography>
           Homebrewed Rule Sets for the Campaign for you to Download
         </Typography>
-      </Grid>
-      <Grid item>
+      </Box>
+      <Box>
         <MuiList>
           {data.documentsCollection.items.map((document: any) => (
             <ListItem key={document.title}>
@@ -44,8 +45,8 @@ export default function Documents() {
             </ListItem>
           ))}
         </MuiList>
-      </Grid>
-    </Grid>
+      </Box>
+    </Stack>
   ) : (
     <></>
   );

--- a/src/Pages/History/History.tsx
+++ b/src/Pages/History/History.tsx
@@ -6,7 +6,8 @@ import TimelineDot from "@mui/lab/TimelineDot";
 import TimelineContent from "@mui/lab/TimelineContent";
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -41,23 +42,23 @@ export default function History() {
           <TimelineContent>
             <Accordion>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Grid
-                  container
+                <Stack
                   justifyContent="space-between"
                   textAlign="center"
                   alignItems="center"
+                  direction="row"
                 >
-                  <Grid item>
+                  <Box>
                     <Typography fontSize={20} variant="h3">
                       836 AF
                     </Typography>
-                  </Grid>
-                  <Grid item>
+                  </Box>
+                  <Box>
                     <Typography variant="h3" fontSize={30}>
                       Present Day
                     </Typography>
-                  </Grid>
-                </Grid>
+                  </Box>
+                </Stack>
               </AccordionSummary>
               <AccordionDetails>
                 <Typography textAlign="justify">

--- a/src/Pages/Missions/Missions.tsx
+++ b/src/Pages/Missions/Missions.tsx
@@ -1,5 +1,5 @@
 import TreeView from "@mui/lab/TreeView";
-import { Grid, Skeleton, Typography } from "@mui/material";
+import { Stack, Box, Skeleton, Typography } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { useGetMissionsPageQuery } from "../../Store/slices/backend";
@@ -43,21 +43,19 @@ export default function Missions() {
     </Typography>
   );
   return (
-    <Grid container flexDirection="column">
-      <Grid item justifyContent="center">
+    <Stack direction="column">
+      <Box sx={{ textAlign: "center" }}>
         <Typography textAlign="center" variant="h2">
           {data?.title}
         </Typography>
-      </Grid>
-      <Grid container flexDirection="row" justifyContent="center" gap={6}>
-        <Grid
-          item
-          xs={12}
-          sm={4}
+      </Box>
+      <Stack direction="row" justifyContent="center" gap={6}>
+        <Box
           sx={{
             border: "1px solid white",
             padding: 3,
             borderBottomRightRadius: 10,
+            width: { xs: "100%", sm: "33%" },
           }}
         >
           <TreeView
@@ -68,23 +66,20 @@ export default function Missions() {
           >
             {selection}
           </TreeView>
-        </Grid>
-        <Grid
-          container
-          item
-          xs={12}
-          sm={7}
+        </Box>
+        <Stack
+          direction="column"
           gap={4}
-          flexDirection="column"
           sx={{
             border: "1px solid white",
             padding: 3,
             borderBottomRightRadius: 10,
+            width: { xs: "100%", sm: "58%" },
           }}
         >
           {mission}
-        </Grid>
-      </Grid>
-    </Grid>
+        </Stack>
+      </Stack>
+    </Stack>
   );
 }

--- a/src/Pages/Sessions/Sessions.tsx
+++ b/src/Pages/Sessions/Sessions.tsx
@@ -6,7 +6,7 @@ import { useGetSessionsDataQuery } from "../../Store/slices/backend";
 import theme from "../../theme";
 import { ESessionType } from "../../Types/Enum/sessions.enum";
 import { TSession } from "../../Types/Types/session.type";
-import { Box, Grid, Tabs } from "@mui/material";
+import { Box, Stack, Tabs } from "@mui/material";
 import { StyledTab } from "./SessionsStyled";
 
 export enum Campaigns {
@@ -77,9 +77,9 @@ export default function Sessions() {
         <StyledTab label="Eldoria" />
         <StyledTab label="Tordenhelm" />
       </Tabs>
-      <Grid item container direction="column" justifyContent="center">
+      <Stack direction="column" justifyContent="center">
         {sessions}
-      </Grid>
+      </Stack>
     </Box>
   );
 }

--- a/src/Pages/Welcome/Welcome.tsx
+++ b/src/Pages/Welcome/Welcome.tsx
@@ -1,5 +1,6 @@
 import Typography from "@mui/material/Typography";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 import { useGetFrontPageQuery } from "../../Store/slices/backend";
 import { useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
@@ -25,28 +26,28 @@ export default function Welcome() {
   );
 
   return (
-    <Grid item container direction="column">
+    <Stack direction="column">
       {data && !isLoading ? (
         <>
-          <Grid item>
+          <Box>
             <Typography variant="h4" align="center">
               <span>{data.pageTitle}</span>
             </Typography>
             <StyledPaper>
-              <Grid item container direction="column">
-                <Grid item>
+              <Stack direction="column">
+                <Box>
                   <Typography variant="h2" textAlign="center">
                     Next Session
                   </Typography>
-                </Grid>
-                <Grid item>
+                </Box>
+                <Box>
                   <Typography variant="h4" textAlign="center">
                     {nextSessionDate}
                   </Typography>
-                </Grid>
-              </Grid>
+                </Box>
+              </Stack>
             </StyledPaper>
-          </Grid>
+          </Box>
           <RichContentRenderer content={data.introduction} />
         </>
       ) : (
@@ -56,6 +57,6 @@ export default function Welcome() {
           <Skeleton variant="rectangular" />
         </>
       )}
-    </Grid>
+    </Stack>
   );
 }

--- a/src/Templates/Main.tsx
+++ b/src/Templates/Main.tsx
@@ -1,5 +1,6 @@
 import Container from "@mui/material/Container";
-import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 import Navbar from "../Components/Molecule/Navbar/Navbar";
 import Draw from "../Components/Molecule/Draw/Draw";
 import { ReactNode } from "react";
@@ -24,14 +25,12 @@ export default function MainTemplate({
   return (
     <>
       <Container maxWidth="lg">
-        <Grid container direction={"column"}>
-          <Grid item sx={{ position: "fixed", zIndex: 100, left: 0 }}>
+        <Stack direction={"column"}>
+          <Box sx={{ position: "fixed", zIndex: 100, left: 0 }}>
             <Navbar onMenuButtonClick={NavbarProps.onMenuButtonClick} />
-          </Grid>
-          <Grid item sx={{ mt: 30 }}>
-            {children}
-          </Grid>
-        </Grid>
+          </Box>
+          <Box sx={{ mt: 30 }}>{children}</Box>
+        </Stack>
       </Container>
       <div>
         <Draw


### PR DESCRIPTION
## Summary
- replace deprecated `Grid` components
- use `Stack` and `Box` for layout

## Testing
- `CI=true yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68822da12ffc8327a97789ee05196f17