### PR TITLE
Improve readability of textProcessor

### DIFF
--- a/src/helpers/text_processor/text_processor.ts
+++ b/src/helpers/text_processor/text_processor.ts
@@ -2,38 +2,38 @@ import { MALFORMED_LINK_TAG } from "../../Constants/error_warnings";
 import { ETextBlockType } from "../../Types/Enum/text_block.enum";
 import { TTextBlock } from "../../Types/Types/text_block.type";
 
+/**
+ * Convert a text block that contains custom [link](label){path} markup into
+ * an array describing the plain text and link segments. This is used by the
+ * TextBlock component to render mixed content.
+ */
 export const textProcessor = (text: string): TTextBlock[] => {
-  const openingLink = (text.match(/\[link\]/g) || [])?.length;
-  const closingLink = (text.match(/\[\/link\]/g) || [])?.length;
-  if (openingLink && closingLink && openingLink === closingLink) {
-    return text.split(/\[link\]|\[\/link\]/g).map((item, i) => {
-      if (i % 2 === 1) {
-        const matches = item
-          .match(/(?:\()(.*?)(?=\))|(?:\{)(.*?)(?=\})/g)
-          ?.map((match) => match.replace(/[({}]/, ""));
-        if (!matches || !matches[0] || !matches[1]) {
-          console.warn(MALFORMED_LINK_TAG);
-          return {
-            textType: ETextBlockType.Text,
-            displayText: item,
-          };
-        }
-        return {
-          textType: ETextBlockType.Link,
-          displayText: matches[0],
-          path: matches[1],
-        };
-      }
-      return {
-        textType: ETextBlockType.Text,
-        displayText: item,
-      };
-    });
+  const openTags = (text.match(/\[link\]/g) || []).length;
+  const closeTags = (text.match(/\[\/link\]/g) || []).length;
+
+  if (!openTags || !closeTags || openTags !== closeTags) {
+    return [{ textType: ETextBlockType.Text, displayText: text }];
   }
-  return [
-    {
-      textType: ETextBlockType.Text,
-      displayText: text,
-    },
-  ];
+
+  return text.split(/\[link\]|\[\/link\]/g).map((segment, index) => {
+    if (index % 2 === 0) {
+      return { textType: ETextBlockType.Text, displayText: segment };
+    }
+
+    const matches = segment
+      .match(/(?:\()(.*?)(?=\))|(?:\{)(.*?)(?=\})/g)
+      ?.map((match) => match.replace(/[({}]/g, ""));
+
+    if (!matches || matches.length < 2) {
+      console.warn(MALFORMED_LINK_TAG);
+      return { textType: ETextBlockType.Text, displayText: segment };
+    }
+
+    return {
+      textType: ETextBlockType.Link,
+      displayText: matches[0],
+      path: matches[1],
+    };
+  });
 };
+


### PR DESCRIPTION
## Summary
- refactor `textProcessor` helper for clarity and comment usage

## Testing
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6882356ebfec832790a26d06b5b5fcd7