### PR TITLE
Improve test coverage over 80%

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,16 @@
 module.exports = {
   roots: ["<rootDir>/src"],
-  collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}", "!src/**/*.d.ts"],
+  collectCoverageFrom: [
+    "src/**/*.{js,jsx,ts,tsx}",
+    "!src/**/*.d.ts",
+    "!src/**/*.stories.tsx",
+    "!src/**/__stories__/**",
+    "!src/Types/**",
+    "!src/**/*.type.ts",
+    "!src/**/*.interface.ts",
+    "!src/index.tsx",
+    "!src/reportWebVitals.ts",
+  ],
   setupFiles: ["react-app-polyfill/jsdom"],
   setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
   testMatch: [
@@ -18,6 +28,13 @@ module.exports = {
     "node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)",
     "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
     "^.+\\.module\\.(css|sass|scss)$",
+  ],
+  coveragePathIgnorePatterns: [
+    "\\.stories\\.tsx$",
+    "/__stories__/",
+    "<rootDir>/src/Types/",
+    "\\.interface\\.ts$",
+    "\\.type\\.ts$",
   ],
   modulePaths: [],
   moduleNameMapper: {

--- a/src/Components/Molecule/EmbeddedVideo/EmbeddedVideo.spec.tsx
+++ b/src/Components/Molecule/EmbeddedVideo/EmbeddedVideo.spec.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import EmbeddedVideo from "./EmbeddedVideo";
+
+describe("Molecule - EmbeddedVideo", () => {
+  it("renders iframe with youtube url", () => {
+    const { getByTitle } = render(
+      <EmbeddedVideo videoId="123" title="video" />
+    );
+    const iframe = getByTitle("video") as HTMLIFrameElement;
+    expect(iframe).toHaveAttribute(
+      "src",
+      "https://www.youtube.com/embed/123"
+    );
+  });
+
+  it("adds autoplay when enabled", () => {
+    const { getByTitle } = render(
+      <EmbeddedVideo videoId="abc" title="auto" autoPlay />
+    );
+    const iframe = getByTitle("auto") as HTMLIFrameElement;
+    expect(iframe).toHaveAttribute(
+      "src",
+      "https://www.youtube.com/embed/abc?autoplay=1"
+    );
+  });
+});

--- a/src/Components/Molecule/Line/Line.spec.tsx
+++ b/src/Components/Molecule/Line/Line.spec.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import Line from "./Line";
+
+describe("Molecule - Line", () => {
+  it("renders line element with coordinates", () => {
+    const { container } = render(
+      <Line x1={0} y1={1} x2={2} y2={3} divHeight={10} divWidth={20} />
+    );
+    const line = container.querySelector("line");
+    expect(line).toHaveAttribute("x1", "0");
+    expect(line).toHaveAttribute("y1", "1");
+    expect(line).toHaveAttribute("x2", "2");
+    expect(line).toHaveAttribute("y2", "3");
+  });
+});

--- a/src/Components/Molecule/MissionDetails/MissionDetails.spec.tsx
+++ b/src/Components/Molecule/MissionDetails/MissionDetails.spec.tsx
@@ -1,0 +1,66 @@
+import { fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "../../../utils/test-utils";
+import MissionDetails from "./MissionDetails";
+import { useNavigate } from "react-router-dom";
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+
+describe("Molecule - MissionDetails", () => {
+  beforeEach(() => {
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+    mockNavigate.mockClear();
+  });
+
+  it("dispatches mission and navigates on map click", () => {
+    const missionLocation = {
+      name: "loc",
+      xCoordinate: 1,
+      yCoordinate: 2,
+      imageWidth: 3,
+      imageHeight: 4,
+      mapReference: { sys: { id: "map-id" } },
+    };
+
+    const { store, getByText } = renderWithProviders(
+      <MissionDetails
+        missionName="mission"
+        location="here"
+        setter="npc"
+        reward="gold"
+        description="desc"
+        missionLocation={missionLocation}
+      />
+    );
+
+    fireEvent.click(getByText("Map"));
+
+    const state = store.getState();
+    expect(state.activeMission.mission).toEqual({
+      missionName: "mission",
+      location: "here",
+      setter: "npc",
+      reward: "gold",
+      description: "desc",
+      missionLocation,
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/map/" + missionLocation.mapReference.sys.id);
+  });
+
+  it("does not render map button without mission location", () => {
+    const { queryByText } = renderWithProviders(
+      <MissionDetails
+        missionName="mission"
+        location="here"
+        setter="npc"
+        reward="gold"
+        description="desc"
+      />
+    );
+    expect(queryByText("Map")).toBeNull();
+  });
+});

--- a/src/Store/slices/modals.spec.ts
+++ b/src/Store/slices/modals.spec.ts
@@ -1,0 +1,19 @@
+import reducer, { openSingleModal, closeAll, selectModalStatus, EnumModalSlice } from "./modals";
+
+describe("modals slice", () => {
+  it("opens a single modal", () => {
+    const state = reducer(undefined, openSingleModal(EnumModalSlice.Menu));
+    expect(state[EnumModalSlice.Menu]).toBe(true);
+  });
+
+  it("closes all modals", () => {
+    const current = { [EnumModalSlice.Menu]: true } as any;
+    const state = reducer(current, closeAll());
+    expect(state[EnumModalSlice.Menu]).toBe(false);
+  });
+
+  it("selectModalStatus returns modal state", () => {
+    const slice = { [EnumModalSlice.Menu]: true } as any;
+    expect(selectModalStatus(slice, EnumModalSlice.Menu)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore helper files from coverage and exclude stories
- add unit tests for EmbeddedVideo and Line components
- add tests for MissionDetails component
- add tests for modals slice

## Testing
- `npm test -- --coverage --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68827743afb88327864b8f5cb8c37d32